### PR TITLE
Updated benchmarks, replaced rust-crypto with RustCrypto crates

### DIFF
--- a/pbkdf2-bench/Cargo.toml
+++ b/pbkdf2-bench/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 
 [dependencies]
 time = "0.1"
-fastpbkdf2 = { git = "https://github.com/ctz/rust-fastpbkdf2" }
-ring = { git = "https://github.com/briansmith/ring" }
-rust-crypto = "0.2"
+fastpbkdf2 = { path = "../"}
+ring = "0.11"
+pbkdf2 = "0.1"
+sha-1 = "0.4"
+sha2 = "0.6"
+hmac = "0.4"

--- a/pbkdf2-bench/min.py
+++ b/pbkdf2-bench/min.py
@@ -3,7 +3,6 @@ all = []
 
 for i in range(1, 6):
     lines = open('out.%d' % i).readlines()
-    lines = lines[1:]
     lines = [l.strip() for l in lines]
     all.append(lines)
 

--- a/pbkdf2-bench/src/main.rs
+++ b/pbkdf2-bench/src/main.rs
@@ -38,46 +38,48 @@ fn fastpbkdf2_sha512() {
 
 // ring versions
 extern crate ring;
-use ring::{pbkdf2_hmac, digest};
+use ring::pbkdf2 as ring_pbkfd2;
+use ring::digest;
 
 fn ring_sha1() {
   let mut out = [0u8; 20];
-  pbkdf2_hmac::derive(&digest::SHA1, ITERATIONS as usize, PASSWORD, SALT, &mut out);
+  ring_pbkfd2::derive(&digest::SHA1, ITERATIONS, PASSWORD, SALT, &mut out);
 }
 
 fn ring_sha256() {
   let mut out = [0u8; 32];
-  pbkdf2_hmac::derive(&digest::SHA256, ITERATIONS as usize, PASSWORD, SALT, &mut out);
+  ring_pbkfd2::derive(&digest::SHA256, ITERATIONS, PASSWORD, SALT, &mut out);
 }
 
 fn ring_sha512() {
   let mut out = [0u8; 64];
-  pbkdf2_hmac::derive(&digest::SHA512, ITERATIONS as usize, PASSWORD, SALT, &mut out);
+  ring_pbkfd2::derive(&digest::SHA512, ITERATIONS, PASSWORD, SALT, &mut out);
 }
 
 // rust-crypto versions
-extern crate crypto;
-use crypto::pbkdf2;
-use crypto::hmac::Hmac;
-use crypto::sha2::{Sha256, Sha512};
-use crypto::sha1::Sha1;
+extern crate sha_1;
+extern crate sha2;
+extern crate hmac;
+extern crate pbkdf2;
+
+use pbkdf2::pbkdf2;
+use hmac::Hmac;
+use sha2::{Sha256, Sha512};
+use sha_1::Sha1;
 
 fn rustcrypto_sha1() {
   let mut out = [0u8; 20];
-  let mut mac = Hmac::new(Sha1::new(), PASSWORD);
-  pbkdf2::pbkdf2(&mut mac, SALT, ITERATIONS, &mut out);
+  pbkdf2::<Hmac<Sha1>>(PASSWORD, SALT, ITERATIONS as usize, &mut out);
 }
 
 fn rustcrypto_sha256() {
   let mut out = [0u8; 32];
-  let mut mac = Hmac::new(Sha256::new(), PASSWORD);
-  pbkdf2::pbkdf2(&mut mac, SALT, ITERATIONS, &mut out);
+  pbkdf2::<Hmac<Sha256>>(PASSWORD, SALT, ITERATIONS as usize, &mut out);
 }
 
 fn rustcrypto_sha512() {
   let mut out = [0u8; 64];
-  let mut mac = Hmac::new(Sha512::new(), PASSWORD);
-  pbkdf2::pbkdf2(&mut mac, SALT, ITERATIONS, &mut out);
+  pbkdf2::<Hmac<Sha512>>(PASSWORD, SALT, ITERATIONS as usize, &mut out);
 }
 
 fn main() {


### PR DESCRIPTION
Updated `ring` to the newest version. Replaced `rust-crypto` with [RustCrypto](https://github.com/RustCrypto) crates. I think it's worth to update readme with the new results. On my PC I got:
```
fastpbkdf2-sha1 = 254ms 
fastpbkdf2-sha256 = 784ms 
fastpbkdf2-sha512 = 1004ms 
ring-sha1 = 959ms 3.77559055118
ring-sha256 = 677ms 0.863520408163
ring-sha512 = 921ms 0.917330677291
rust-crypto-sha1 = 461ms 1.81496062992
rust-crypto-sha256 = 981ms 1.2512755102
rust-crypto-sha512 = 1349ms 1.34362549801
```