### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastpbkdf2"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["jpixton@gmail.com"]
 license = "CC0-1.0"
 readme = "README.md"
@@ -17,8 +17,8 @@ name = "fastpbkdf2"
 path = "src/lib.rs"
 
 [dependencies]
-libc = "0.1"
+libc = "0.2"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"
 

--- a/build.rs
+++ b/build.rs
@@ -1,21 +1,21 @@
-extern crate gcc;
+extern crate cc;
 
 #[cfg(not(windows))]
 fn main() {
-  gcc::Config::new()
-    .file("fastpbkdf2/fastpbkdf2.c")
-    .include("fastpbkdf2/")
-    .flag("-std=c99")
-    .opt_level(3)
-    .compile("libfastpbkdf2.a");
+    cc::Build::new()
+        .file("fastpbkdf2/fastpbkdf2.c")
+        .include("fastpbkdf2/")
+        .flag("-std=c99")
+        .opt_level(3)
+        .compile("libfastpbkdf2.a");
 }
 
 #[cfg(windows)]
 fn main() {
-  gcc::Config::new()
-    .file("fastpbkdf2\\fastpbkdf2.c")
-    .include("fastpbkdf2\\")
-    .include("fastpbkdf2\\openssl\\include")
-    .opt_level(3)
-    .compile("libfastpbkdf2.a");
+    cc::Build::new()
+        .file("fastpbkdf2\\fastpbkdf2.c")
+        .include("fastpbkdf2\\")
+        .include("fastpbkdf2\\openssl\\include")
+        .opt_level(3)
+        .compile("libfastpbkdf2.a");
 }


### PR DESCRIPTION
libc: 0.1 to 0.2
gcc: 0.3 to cc 1.0 (see https://crates.io/crates/gcc)
fastpbkdf2 submodule updated to latest commit
Update version to 0.2.0

I'm aware that in #3 you suggested people use ring instead, but if this project isn't going to be maintained please update crates.io to point users towards ring & archive this repo