### PR TITLE
Fix outdated dependencies, outdated test code and warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ readme = "README.md"
 homepage = "https://github.com/ctz/rust-fastpbkdf2"
 repository = "https://github.com/ctz/rust-fastpbkdf2"
 description = "A rust binding for fastpbkdf2.  This is a PBKDF2 with HMAC-SHA1, HMAC-SHA256 and HMAC-SHA512 and is faster than other implementations."
-keywords = ["pbkdf2", "fastpbkdf2" ]
+keywords = ["pbkdf2", "fastpbkdf2"]
+edition = "2018"
 
 links = "fastpbkdf2"
 build = "build.rs"
@@ -17,8 +18,7 @@ name = "fastpbkdf2"
 path = "src/lib.rs"
 
 [dependencies]
-libc = "0.1"
+libc = "0.2"
 
 [build-dependencies]
-gcc = "0.3"
-
+cc = "1.2"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ On Intel i3-2100T CPU @ 2.50GHz in 64-bit mode, 2<sup>20</sup> iterations, `--re
 
 You'll need OpenSSL for `fastpbkdf2`.  `cargo build` builds, `cargo test` runs tests.
 
+Don't forget checking out the `fastpbkdf2` git submodule before building.
+
+Consider enabling CPU-specific optimizations such as [-C target-cpu=native](https://doc.rust-lang.org/rustc/codegen-options/index.html#target-cpu) if the compiled binaries are used locally or on a controlled machine type.
+
+### Linux
+
+OpenSSL libraries are typically available as either `openssl-dev`, `openssl-devel`, `libssl-dev` or similar package names.
+
+
 ### Windows
 
 You'll [need to provide an OpenSSL build to fastpbkdf2](https://github.com/ctz/fastpbkdf2/blob/master/WINDOWS.md#OpenSSL) (inside its submodule).

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,8 @@
-extern crate gcc;
+extern crate cc;
 
 #[cfg(not(windows))]
 fn main() {
-  gcc::Config::new()
+  cc::Build::new()
     .file("fastpbkdf2/fastpbkdf2.c")
     .include("fastpbkdf2/")
     .flag("-std=c99")

--- a/pbkdf2-bench/Cargo.toml
+++ b/pbkdf2-bench/Cargo.toml
@@ -2,9 +2,14 @@
 name = "pbkdf2-bench"
 version = "0.1.0"
 authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
+edition = "2018"
 
 [dependencies]
-time = "0.1"
-fastpbkdf2 = { git = "https://github.com/ctz/rust-fastpbkdf2" }
-ring = { git = "https://github.com/briansmith/ring" }
-rust-crypto = "0.2"
+# version 0.3 removed SteadyTime
+time = "0.2"
+fastpbkdf2 = { path = "../" }
+ring = "0.17"
+pbkdf2 = "0.12"
+sha-1 = "0.10"
+sha2 = "0.10"
+hmac = "0.12"

--- a/pbkdf2-bench/min.py
+++ b/pbkdf2-bench/min.py
@@ -3,7 +3,8 @@ all = []
 
 for i in range(1, 6):
     lines = open('out.%d' % i).readlines()
-    lines = lines[1:]
+    # TODO
+    # lines = lines[1:]
     lines = [l.strip() for l in lines]
     all.append(lines)
 

--- a/pbkdf2-bench/src/main.rs
+++ b/pbkdf2-bench/src/main.rs
@@ -1,4 +1,3 @@
-
 // I'd like to have used test::Bencher and `cargo bench` here,
 // but it's not usable in current stable rust :(
 //
@@ -12,84 +11,107 @@ const ITERATIONS: u32 = 1 << 20;
 const PASSWORD: &'static [u8] = b"password";
 const SALT: &'static [u8] = b"salt";
 
-fn bench<F>(name: &'static str, f: F) where F: FnOnce() {
-  let start = SteadyTime::now();
-  f();
-  let duration = SteadyTime::now() - start;
-  println!("{} = {}ms", name, duration.num_milliseconds());
+fn bench<F>(name: &'static str, f: F)
+where
+    F: FnOnce(),
+{
+    let start = SteadyTime::now();
+    f();
+    let duration = SteadyTime::now() - start;
+    println!("{} = {}ms", name, duration.num_milliseconds());
 }
 
 // fastpbkdf2 versions
 extern crate fastpbkdf2;
+
 fn fastpbkdf2_sha1() {
-  let mut out = [0u8; 20];
-  fastpbkdf2::pbkdf2_hmac_sha1(PASSWORD, SALT, ITERATIONS, &mut out);
+    let mut out = [0u8; 20];
+    fastpbkdf2::pbkdf2_hmac_sha1(PASSWORD, SALT, ITERATIONS, &mut out);
 }
 
 fn fastpbkdf2_sha256() {
-  let mut out = [0u8; 32];
-  fastpbkdf2::pbkdf2_hmac_sha256(PASSWORD, SALT, ITERATIONS, &mut out);
+    let mut out = [0u8; 32];
+    fastpbkdf2::pbkdf2_hmac_sha256(PASSWORD, SALT, ITERATIONS, &mut out);
 }
 
 fn fastpbkdf2_sha512() {
-  let mut out = [0u8; 64];
-  fastpbkdf2::pbkdf2_hmac_sha512(PASSWORD, SALT, ITERATIONS, &mut out);
+    let mut out = [0u8; 64];
+    fastpbkdf2::pbkdf2_hmac_sha512(PASSWORD, SALT, ITERATIONS, &mut out);
 }
 
 // ring versions
 extern crate ring;
-use ring::{pbkdf2_hmac, digest};
+use ring::pbkdf2 as ring_pbkfd2;
+use std::num::NonZero;
 
 fn ring_sha1() {
-  let mut out = [0u8; 20];
-  pbkdf2_hmac::derive(&digest::SHA1, ITERATIONS as usize, PASSWORD, SALT, &mut out);
+    let mut out = [0u8; 20];
+    ring_pbkfd2::derive(
+        ring::pbkdf2::PBKDF2_HMAC_SHA1,
+        NonZero::new(ITERATIONS).unwrap(),
+        PASSWORD,
+        SALT,
+        &mut out,
+    );
 }
 
 fn ring_sha256() {
-  let mut out = [0u8; 32];
-  pbkdf2_hmac::derive(&digest::SHA256, ITERATIONS as usize, PASSWORD, SALT, &mut out);
+    let mut out = [0u8; 32];
+    ring_pbkfd2::derive(
+        ring::pbkdf2::PBKDF2_HMAC_SHA256,
+        NonZero::new(ITERATIONS).unwrap(),
+        PASSWORD,
+        SALT,
+        &mut out,
+    );
 }
 
 fn ring_sha512() {
-  let mut out = [0u8; 64];
-  pbkdf2_hmac::derive(&digest::SHA512, ITERATIONS as usize, PASSWORD, SALT, &mut out);
+    let mut out = [0u8; 64];
+    ring_pbkfd2::derive(
+        ring::pbkdf2::PBKDF2_HMAC_SHA512,
+        NonZero::new(ITERATIONS).unwrap(),
+        PASSWORD,
+        SALT,
+        &mut out,
+    );
 }
 
 // rust-crypto versions
-extern crate crypto;
-use crypto::pbkdf2;
-use crypto::hmac::Hmac;
-use crypto::sha2::{Sha256, Sha512};
-use crypto::sha1::Sha1;
+extern crate hmac;
+extern crate pbkdf2;
+extern crate sha1;
+extern crate sha2;
+use hmac::Hmac;
+use pbkdf2::pbkdf2;
+use sha1::Sha1;
+use sha2::{Sha256, Sha512};
 
 fn rustcrypto_sha1() {
-  let mut out = [0u8; 20];
-  let mut mac = Hmac::new(Sha1::new(), PASSWORD);
-  pbkdf2::pbkdf2(&mut mac, SALT, ITERATIONS, &mut out);
+    let mut out = [0u8; 20];
+    let _ = pbkdf2::<Hmac<Sha1>>(PASSWORD, SALT, ITERATIONS, &mut out);
 }
 
 fn rustcrypto_sha256() {
-  let mut out = [0u8; 32];
-  let mut mac = Hmac::new(Sha256::new(), PASSWORD);
-  pbkdf2::pbkdf2(&mut mac, SALT, ITERATIONS, &mut out);
+    let mut out = [0u8; 32];
+    let _ = pbkdf2::<Hmac<Sha256>>(PASSWORD, SALT, ITERATIONS, &mut out);
 }
 
 fn rustcrypto_sha512() {
-  let mut out = [0u8; 64];
-  let mut mac = Hmac::new(Sha512::new(), PASSWORD);
-  pbkdf2::pbkdf2(&mut mac, SALT, ITERATIONS, &mut out);
+    let mut out = [0u8; 64];
+    let _ = pbkdf2::<Hmac<Sha512>>(PASSWORD, SALT, ITERATIONS, &mut out);
 }
 
 fn main() {
-  bench("fastpbkdf2-sha1", fastpbkdf2_sha1);
-  bench("fastpbkdf2-sha256", fastpbkdf2_sha256);
-  bench("fastpbkdf2-sha512", fastpbkdf2_sha512);
+    bench("fastpbkdf2-sha1", fastpbkdf2_sha1);
+    bench("fastpbkdf2-sha256", fastpbkdf2_sha256);
+    bench("fastpbkdf2-sha512", fastpbkdf2_sha512);
 
-  bench("ring-sha1", ring_sha1);
-  bench("ring-sha256", ring_sha256);
-  bench("ring-sha512", ring_sha512);
+    bench("ring-sha1", ring_sha1);
+    bench("ring-sha256", ring_sha256);
+    bench("ring-sha512", ring_sha512);
 
-  bench("rust-crypto-sha1", rustcrypto_sha1);
-  bench("rust-crypto-sha256", rustcrypto_sha256);
-  bench("rust-crypto-sha512", rustcrypto_sha512);
+    bench("rust-crypto-sha1", rustcrypto_sha1);
+    bench("rust-crypto-sha256", rustcrypto_sha256);
+    bench("rust-crypto-sha512", rustcrypto_sha512);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,14 +4,14 @@ use libc::size_t;
 #[cfg(not(windows))]
 #[link(name = "fastpbkdf2")]
 #[link(name = "crypto")]
-extern {}
+extern "C" {}
 
 #[cfg(windows)]
 #[link(name = "fastpbkdf2")]
 #[link(name = "fastpbkdf2/openssl/lib/libeay32")]
 extern {}
 
-extern {
+extern "C" {
   fn fastpbkdf2_hmac_sha1(pw: *const u8, npw: size_t,
                           salt: *const u8, nsalt: size_t,
                           iterations: u32,


### PR DESCRIPTION
This PR is based on #2 and #4, with thanks to the respective authors @cryptogun and @newpavlov.

Update the crate and the benchmark sub-crate to less outdated dependency and Rust versions, use the newest fastpbkdf2 commit.

@ctz : I understand that you don't want to do a lot of maintenance for this crate or encourage its usage, as outlined in #3. Among other things, SHA1 and SHA256 implementations in Rust have gotten faster over the years by using specialized CPU instructions, which reduces the lead of `fastpbkdf2` over those common crates or even has it at a disadvantage. For example, `fastpbkdf2-sha1` was slower in tests than `rust-crypto-sha1` in the benchmarks on AMD Zen4 7950X3D and `RUSTFLAGS="-C target-cpu=native"`. Generally, users  should find out which of the widely used cryptography crates (from RustCrypto, ring and so on) works best for them and stick with those.

That said, there are still niche areas - especially in security research - where your fastpbkdf2 & Rust binding combination still shines and considerably outperforms existing solutions, for SHA512 in particular. I've seen speed increases of roughly 25-40% more PBKDF2 iterations per CPU core over other optimized implementations. This is very useful for CPU-bound brute force programs if no GPU options are available. 
For these reasons, having a less outdated version of the crate would be great, and that's the idea of this PR.

On the C code side, OpenSSL 3.0 warns about deprecated APIs but the calls still work. Fixing that would require changes to https://github.com/ctz/fastpbkdf2 and is out of scope here.

If you want to be be explicit about the limitations of this crate, I recommend updating the README to outline that this crate should not be used in production, and receives very limited maintenance.